### PR TITLE
Style New Carrer Plan Page

### DIFF
--- a/CareerPlan.iOS/CareerPlan.iOS.csproj
+++ b/CareerPlan.iOS/CareerPlan.iOS.csproj
@@ -68,6 +68,7 @@
     <None Include="Entitlements.plist" />
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CustomRenders\OutlineEditorRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />
@@ -132,5 +133,8 @@
       <Project>{C866327A-4860-43FF-9AA8-C0E2A469F309}</Project>
       <Name>CareerPlan</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="CustomRenders\" />
   </ItemGroup>
 </Project>

--- a/CareerPlan.iOS/CustomRenders/OutlineEditorRenderer.cs
+++ b/CareerPlan.iOS/CustomRenders/OutlineEditorRenderer.cs
@@ -1,0 +1,28 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+using CareerPlan.Custom;
+using CareerPlan.iOS.CustomRenders;
+
+
+[assembly: ExportRenderer(typeof(OutlineEditor), typeof(OutlineEditorRenderer))]
+namespace CareerPlan.iOS.CustomRenders
+{
+    public class OutlineEditorRenderer : EditorRenderer
+    {
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
+        {
+            base.OnElementChanged(e);
+
+            if (Control != null)
+            {
+                Control.TextContainerInset = new UIKit.UIEdgeInsets(10, 7, 10, 7);
+                Control.BackgroundColor = Color.Transparent.ToUIColor();
+                Control.Layer.CornerRadius = 4;
+                Control.Layer.BorderWidth = 1;
+                Control.Layer.BorderColor = Color.FromHex("b3b3b3").ToCGColor();
+            }
+        }
+
+    }
+}

--- a/CareerPlan/CareerPlan.csproj
+++ b/CareerPlan/CareerPlan.csproj
@@ -18,9 +18,11 @@
   <ItemGroup>
     <None Remove="Models\" />
     <None Remove="View Models\" />
+    <None Remove="Custom\" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Models\" />
     <Folder Include="View Models\" />
+    <Folder Include="Custom\" />
   </ItemGroup>
 </Project>

--- a/CareerPlan/Custom/Control.cs
+++ b/CareerPlan/Custom/Control.cs
@@ -1,0 +1,8 @@
+﻿using Xamarin.Forms;
+
+namespace CareerPlan.Custom
+{
+    public class OutlineEditor: Editor
+    {
+    }
+}

--- a/CareerPlan/Views/NewPlan.xaml
+++ b/CareerPlan/Views/NewPlan.xaml
@@ -2,7 +2,8 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CareerPlan.Views.NewPlanPage"
-             Title="Nuevo Plan de Carrera">
+             Title="Nuevo Plan de Carrera"
+             BackgroundColor="#F7F7F7">
     <StackLayout Padding="15">
 
         <Label Text="Nombre" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>

--- a/CareerPlan/Views/NewPlan.xaml
+++ b/CareerPlan/Views/NewPlan.xaml
@@ -1,40 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="CareerPlan.Views.NewPlanPage">
+             x:Class="CareerPlan.Views.NewPlanPage"
+             Title="Nuevo Plan de Carrera">
+    <StackLayout Padding="15">
 
-    <StackLayout>
-        <Frame  Padding="24" CornerRadius="0">
-            <Label Text="Crear nuevo plan de estudio" HorizontalTextAlignment="Center" TextColor="Black" FontSize="36" FontAttributes="Bold"/>
-        </Frame>
+        <Label Text="Nombre" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
         <Entry></Entry>
 
-        <Label Text="Nombre del nuevo plan" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
-
-        <Entry ></Entry>
 
         <Label Text="Código" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
-
         <Entry ></Entry>
 
+
         <Label Text="Descripción" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
+        <Editor></Editor>
 
-
-
-
-        <StackLayout Orientation="Horizontal" HorizontalOptions="Center" >
-            <Button Text="CANCELAR" />
-            <Button Text="SIGUIENTE" />
+        <!--<< ACTION BUTTONS >>-->
+        <StackLayout Orientation="Horizontal"  HorizontalOptions="Center" VerticalOptions="EndAndExpand">
+            <Button Text="CANCELAR" Padding="20, 0" TextColor="#FFF" FontAttributes="Bold" BackgroundColor="#FA7F28" />
+            <Button Text="SIGUIENTE" Padding="20, 0" TextColor="#FFF" FontAttributes="Bold" BackgroundColor="#FA7F28" />
         </StackLayout>
-        
-        <Label FontSize="16" Padding="3,2,30,0">
-        
 
-            
-          
-        </Label>
-        
-        
     </StackLayout>
-
 </ContentPage>

--- a/CareerPlan/Views/NewPlan.xaml
+++ b/CareerPlan/Views/NewPlan.xaml
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
              xmlns:custom="clr-namespace:CareerPlan.Custom"
              x:Class="CareerPlan.Views.NewPlanPage"
+             ios:Page.UseSafeArea="true"
              Title="Nuevo Plan de Carrera"
              BackgroundColor="#F7F7F7">
     <StackLayout Padding="15" Spacing="20">

--- a/CareerPlan/Views/NewPlan.xaml
+++ b/CareerPlan/Views/NewPlan.xaml
@@ -5,23 +5,28 @@
              x:Class="CareerPlan.Views.NewPlanPage"
              Title="Nuevo Plan de Carrera"
              BackgroundColor="#F7F7F7">
-    <StackLayout Padding="15">
+    <StackLayout Padding="15" Spacing="20">
 
-        <Label Text="Nombre" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
-        <Entry></Entry>
+        <!--<< ENTRIES >>-->
+        <StackLayout>
+            <Label Text="Nombre" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
+            <Entry/>
+        </StackLayout>
+        <StackLayout>
+            <Label Text="Código" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
+            <Entry/>
+        </StackLayout>
 
-
-        <Label Text="Código" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
-        <Entry ></Entry>
-
-
-        <Label Text="Descripción" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
-        <Grid>
-            <custom:OutlineEditor AutoSize="TextChanges"/>
-        </Grid>
+        <!--<< TEXT AREA >>-->
+        <StackLayout>
+            <Label Text="Descripción" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
+            <Grid>
+                <custom:OutlineEditor AutoSize="TextChanges"/>
+            </Grid>
+        </StackLayout>
 
         <!--<< ACTION BUTTONS >>-->
-        <StackLayout Orientation="Horizontal" Margin="0, 15, 0, 0" HorizontalOptions="Center" VerticalOptions="EndAndExpand">
+        <StackLayout Orientation="Horizontal" HorizontalOptions="Center" VerticalOptions="EndAndExpand">
             <Button Text="CANCELAR" Padding="20, 0" TextColor="#FFF" FontAttributes="Bold" BackgroundColor="#FA7F28" />
             <Button Text="SIGUIENTE" Padding="20, 0" TextColor="#FFF" FontAttributes="Bold" BackgroundColor="#FA7F28" />
         </StackLayout>

--- a/CareerPlan/Views/NewPlan.xaml
+++ b/CareerPlan/Views/NewPlan.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:custom="clr-namespace:CareerPlan.Custom"
              x:Class="CareerPlan.Views.NewPlanPage"
              Title="Nuevo Plan de Carrera"
              BackgroundColor="#F7F7F7">
@@ -15,10 +16,12 @@
 
 
         <Label Text="Descripción" FontSize="16" Padding="2,0,30,0" FontAttributes="Bold"/>
-        <Editor></Editor>
+        <Grid>
+            <custom:OutlineEditor AutoSize="TextChanges"/>
+        </Grid>
 
         <!--<< ACTION BUTTONS >>-->
-        <StackLayout Orientation="Horizontal"  HorizontalOptions="Center" VerticalOptions="EndAndExpand">
+        <StackLayout Orientation="Horizontal" Margin="0, 15, 0, 0" HorizontalOptions="Center" VerticalOptions="EndAndExpand">
             <Button Text="CANCELAR" Padding="20, 0" TextColor="#FFF" FontAttributes="Bold" BackgroundColor="#FA7F28" />
             <Button Text="SIGUIENTE" Padding="20, 0" TextColor="#FFF" FontAttributes="Bold" BackgroundColor="#FA7F28" />
         </StackLayout>


### PR DESCRIPTION
# Description
Adding style to the new career plan page using the same layout than previous pages. 

For this page I have used a `<editor>` control to allow the user write multi-line text but since the original iOS style of the `<editor>` control doesn't have a good visibility I had to create a custom renderer for iOS called **OutlineEditor** which improves significantly the visibility.

The use of a `<editor>` with the attribute `AutoSize="TextChanges"` creates the possibility to cause a issue displacing the buttons below out of screen device so I have wrapped the control in a `<grid>` layout which default behavior is limit the row height to a maximum of what it can take preventing displacing elements. 

# Issue
Close #19 

# Image
<img width="573" alt="image" src="https://user-images.githubusercontent.com/19566571/145699800-b39f0518-3505-40dc-9344-93589c019945.png">
